### PR TITLE
Generalize to multiple exposures and for dirty directories

### DIFF
--- a/python/lsst/phosim/utils/phosim_repackager.py
+++ b/python/lsst/phosim/utils/phosim_repackager.py
@@ -59,7 +59,7 @@ class PhoSimRepackager:
             Set to True to print out time for processing each sensor.
         """
         phosim_amp_files \
-            = sorted(glob.glob(os.path.join(visit_dir, f'{prefix}_a_*')))
+            = sorted(glob.glob(os.path.join(visit_dir, f'{prefix}_a_*_C*')))
         amp_files = defaultdict(list)
         for item in phosim_amp_files:
             splt = os.path.basename(item).split('_')

--- a/python/lsst/phosim/utils/phosim_repackager.py
+++ b/python/lsst/phosim/utils/phosim_repackager.py
@@ -62,7 +62,8 @@ class PhoSimRepackager:
             = sorted(glob.glob(os.path.join(visit_dir, f'{prefix}_a_*')))
         amp_files = defaultdict(list)
         for item in phosim_amp_files:
-            sensor_id = '_'.join(os.path.basename(item).split('_')[4:6])
+            splt = os.path.basename(item).split('_')
+            sensor_id = '_'.join(splt[4:6] + [splt[7]])
             amp_files[sensor_id].append(item)
         if out_dir is None:
             tokens = os.path.basename(phosim_amp_files[0]).split('_')
@@ -151,6 +152,7 @@ class PhoSimRepackager:
         parts = chip_id.split('_')
         raft = parts[0]
         ccd = parts[1]
+        snap = int(os.path.basename(fn).split('_')[7][1:4])
         sensor[0].header['EXPTIME'] = sensor[1].header['EXPTIME']
         sensor[0].header['DARKTIME'] = sensor[1].header['DARKTIME']
         sensor[0].header['RUNNUM'] = sensor[1].header['OBSID']
@@ -166,6 +168,7 @@ class PhoSimRepackager:
         sensor[0].header['MONOWL'] = -1
         sensor[0].header['RAFTNAME'] = raft
         sensor[0].header['SENSNAME'] = ccd
+        sensor[0].header['SNAP'] = snap
         # Add boresight pointing angles and rotskypos (angle of sky
         # relative to Camera coordinates) from which obs_obs_lsst can
         # infer the CCD-wide WCS.

--- a/setup.cfg
+++ b/setup.cfg
@@ -1,6 +1,6 @@
 [flake8]
 max-line-length = 110
-ignore = E133, E226, E228, N802, N803, N806
+ignore = E133, E226, E228, N802, N803, N806, N812, N813, N815, N816, W504
 exclude =
   bin,
   doc,
@@ -10,4 +10,4 @@ exclude =
 
 [tool:pytest]
 addopts = --flake8
-flake8-ignore = E133 E226 E228 N802 N803 N806
+flake8-ignore = E133 E226 E228 N802 N803 N806 N812 N813 N815 N816 W504


### PR DESCRIPTION
1) Added support for PhoSim images where there are multiple exposures for one visit. 
2) Constrained the glob so that we can run the repackager multiple times without issue.
3) Fixed a prior existing linting issue.

All tests pass.