### PR TITLE
Invert gain

### DIFF
--- a/bin.src/makeGainImages.py
+++ b/bin.src/makeGainImages.py
@@ -52,7 +52,7 @@ def main(just_wfs=False, detector_list=None):
             image = afwImage.ImageF(ccd.getBBox())
             for amp in ccd:
                 subim = afwImage.ImageF(image, amp.getBBox())
-                subim[:] = amp.getGain()
+                subim[:] = 1/amp.getGain()
                 print(amp.getName(), amp.getGain())
             expInfo = afwImage.ExposureInfo()
             inFilter = afwImage.Filter(filt_name)

--- a/setup.cfg
+++ b/setup.cfg
@@ -1,6 +1,6 @@
 [flake8]
 max-line-length = 110
-ignore = E133, E226, E228, N802, N803, N806
+ignore = E133, E226, E228, N802, N803, N806, N812, N813, N815, N816, W504
 exclude =
   bin,
   doc,
@@ -10,4 +10,4 @@ exclude =
 
 [tool:pytest]
 addopts = --flake8
-flake8-ignore = E133 E226 E228 N802 N803 N806
+flake8-ignore = E133 E226 E228 N802 N803 N806 N812 N813 N815 N816 W504


### PR DESCRIPTION
Inverted the gain to be consistent with Phosim. See page 13 of https://arxiv.org/pdf/1504.06570.pdf for the formula PhoSim uses. Note that for our simulations N, the nonlinear contribution, is set to 0.

Also updated flake8 ignores based on LSST guidelines.