### PR TITLE
Tickets/DM-29702: Update ROTANG to match WCS

### DIFF
--- a/python/lsst/phosim/utils/phosim_repackager.py
+++ b/python/lsst/phosim/utils/phosim_repackager.py
@@ -207,6 +207,8 @@ class PhoSimRepackager:
             hdu.header["DETSEC"] = noao_section_keyword(
                 amp.getBBox(), flipx=amp.getRawFlipX(), flipy=amp.getRawFlipY()
             )
+            hdu.header["ROTANG"] += 90.  # add 90 degrees to the rotation angle
+            # to set correct WCS
 
             # Set the filter information.
             # For lsstCam, the phosim filter names (ugrizy)
@@ -408,6 +410,7 @@ class PhoSimRepackager:
         OBSID = f"{self.telcode}_{self.CONTRLLR}_{DAYOBS}_{SEQNUM:06d}"
         sensor.header["OBSID"] = OBSID
 
+        sensor.header["ROTANG"] += 90.  # add 90 degrees to match WCS
         sensor.header["TESTTYPE"] = "PHOSIM"
         sensor.header["IMGTYPE"] = "SKYEXP"
 

--- a/python/lsst/phosim/utils/phosim_repackager.py
+++ b/python/lsst/phosim/utils/phosim_repackager.py
@@ -207,8 +207,9 @@ class PhoSimRepackager:
             hdu.header["DETSEC"] = noao_section_keyword(
                 amp.getBBox(), flipx=amp.getRawFlipX(), flipy=amp.getRawFlipY()
             )
-            hdu.header["ROTANG"] += 90.  # add 90 degrees to the rotation angle
+            # Add 90 degrees to the rotation angle
             # to set correct WCS
+            hdu.header["ROTANG"] += 90.
 
             # Set the filter information.
             # For lsstCam, the phosim filter names (ugrizy)

--- a/tests/test_phosim_repackager.py
+++ b/tests/test_phosim_repackager.py
@@ -261,6 +261,7 @@ class TestPhoSimRepackager(unittest.TestCase):
         self.assertEqual(header["AMPID"], "C10")
         self.assertEqual(header["CCDID"], "R22_S22")
         self.assertEqual(header["EXTNAME"], "Segment10")
+        self.assertEqual(header["ROTANG"], 90)
 
         # Close the file
         hdul.close()


### PR DESCRIPTION
Update ROTANG in the amp and e-image header to match WCS information (it corrects for the 90 degree rotation of `phosim` vs `obs_lsst`, as shown in https://github.com/lsst-ts/phosim_syseng4/pull/6)