### PR TITLE
Tickets/DM-29961: Add FOCUSZ 

### DIFF
--- a/bin.src/phosim_repackager.py
+++ b/bin.src/phosim_repackager.py
@@ -23,8 +23,12 @@ parser.add_argument('--image_type', type=str, default='skyexp',
                     help="image type, passed as 'IMGTYPE': skyexp, dark,\
                     flat, or bias (default: skyexp)")
 parser.add_argument('--focusz', type=float, default=0,
-                    help="The defocal position. For extra-focal it is -1500, for intra-focal 1500,\
-                    for in-focus images 0. (default: 0")
+                    help="The main hexapod position in micrometers. \
+                    For in-focus images it is 0 (default),\
+                    and assuming defocal distance of d (eg. 1500), \
+                    one convention is to set,\
+                    for extra-focal images focusz = -d, \
+                    for intra-focal images focuzs = +d ")
 args = parser.parse_args()
 
 repackager = phosim_utils.PhoSimRepackager(instName=args.inst, image_type=args.image_type,

--- a/bin.src/phosim_repackager.py
+++ b/bin.src/phosim_repackager.py
@@ -22,9 +22,13 @@ parser.add_argument('--verbose', default=False, action='store_true',
 parser.add_argument('--image_type', type=str, default='skyexp',
                     help="image type, passed as 'IMGTYPE': skyexp, dark,\
                     flat, or bias (default: skyexp)")
+parser.add_argument('--focusz', type=float, default=0,
+                    help="The defocal position. For extra-focal it is -1500, for intra-focal 1500,\
+                    for in-focus images 0. (default: 0")
 args = parser.parse_args()
 
-repackager = phosim_utils.PhoSimRepackager(instName=args.inst, image_type=args.image_type)
+repackager = phosim_utils.PhoSimRepackager(instName=args.inst, image_type=args.image_type,
+                                           focusz=args.focusz)
 
 if (args.eimage):
     repackager.process_visit_eimage(args.visit_dir, out_dir=args.out_dir,

--- a/python/lsst/phosim/utils/phosim_repackager.py
+++ b/python/lsst/phosim/utils/phosim_repackager.py
@@ -93,7 +93,7 @@ class PhoSimRepackager:
     # observed (not simulated) data,  added via DM-27863
     # to obs_lsst translators/lsst.py
 
-    def __init__(self, instName="lsst", image_type="skyexp"):
+    def __init__(self, instName="lsst", image_type="skyexp", focusz=0):
         """
         Parameters
         ----------
@@ -107,11 +107,23 @@ class PhoSimRepackager:
             those approved by obs_lsst metadata translator
             for lsstCam or comCam are SKYEXP, FLAT, DARK,
             BIAS. (the default is 'skyexp').
+        focusz: int, optional
+            The position of the main camera hexapod in micrometers.
+            For in-focus image it is 0.
+            Assuming defocal distance of d micrometers,
+            for extra-focal image it would be -d,
+            and for intra-focal image it would be d.
+            Added to the repackaged image
+            primary image header as FOCUSZ.
+            (the default is 0).
+
+        (the default is 0)
         """
         # Use appropriate obs_lsst mapper camera object
         # and telescope code, and declare the image type
         # to be stored in the  header.
         self.image_type = image_type
+        self.focusz = focusz
         if instName == "lsst":
             self.camera = LsstCam().getCamera()
             self.telcode = "MC"  # Main Camera
@@ -230,6 +242,8 @@ class PhoSimRepackager:
         sensor[0].header["EXPTIME"] = sensor[1].header["EXPTIME"]
         sensor[0].header["DARKTIME"] = sensor[1].header["DARKTIME"]
 
+        # Add keyword for defocal position, FOCUSZ
+        sensor[0].header["FOCUSZ"] = self.focusz
         # Call phosim OBSID as RUNNUM to be handled properly
         # by obs_lsst LsstCam or LsstComCam translators
         sensor[0].header["RUNNUM"] = sensor[1].header["OBSID"]

--- a/tests/test_phosim_repackager.py
+++ b/tests/test_phosim_repackager.py
@@ -38,9 +38,12 @@ class TestPhoSimRepackager(unittest.TestCase):
 
     def setUp(self):
 
-        self.phoSim_repackager = PhoSimRepackager()
+        self.phoSim_repackager_lsstcam = PhoSimRepackager(instName='lsst',
+                                                          image_type="skyexp",
+                                                          focusz=-1500)
         self.phoSim_repackager_calib = PhoSimRepackager(instName='lsst', image_type='dark')
-        self.phoSim_repackager_comcam = PhoSimRepackager("comcam")
+        self.phoSim_repackager_comcam = PhoSimRepackager("comcam", image_type="skyexp",
+                                                         focusz=-1500)
 
         package_dir = getPackageDir("phosim_utils")
         test_dir = os.path.join(package_dir, "tests")
@@ -85,29 +88,35 @@ class TestPhoSimRepackager(unittest.TestCase):
     def test_phoSim_repackager_init(self):
 
         # controller is the same for both instruments
-        self.assertEqual(self.phoSim_repackager.CONTRLLR, "H")
+        self.assertEqual(self.phoSim_repackager_lsstcam.CONTRLLR, "H")
         self.assertEqual(self.phoSim_repackager_comcam.CONTRLLR, "H")
 
         # telescope code is different for each instrument
-        self.assertEqual(self.phoSim_repackager.telcode, "MC")
+        self.assertEqual(self.phoSim_repackager_lsstcam.telcode, "MC")
         self.assertEqual(self.phoSim_repackager_comcam.telcode, "CC")
 
         # instrument name is different for each instrument
-        self.assertEqual(self.phoSim_repackager.instrument, "lsstCam")
+        self.assertEqual(self.phoSim_repackager_lsstcam.instrument, "lsstCam")
         self.assertEqual(self.phoSim_repackager_comcam.instrument, "comCam")
 
         # image_type by default is skyexp
-        self.assertEqual(self.phoSim_repackager.image_type, "skyexp")
+        self.assertEqual(self.phoSim_repackager_lsstcam.image_type, "skyexp")
 
         # image_type can be also dark, flat, bias
         self.assertEqual(self.phoSim_repackager_calib.image_type, "dark")
+
+        # focusz is extra-focal, i.e -1500 for lsstcam and comcam test files
+        # but 0 for calibs
+        self.assertEqual(self.phoSim_repackager_lsstcam.focusz, -1500)
+        self.assertEqual(self.phoSim_repackager_comcam.focusz, -1500)
+        self.assertEqual(self.phoSim_repackager_calib.focusz, 0)
 
     def test_process_visit_eimage(self):
 
         num_file = self._get_num_of_file_in_dir(self.tmp_test_dir)
         self.assertEqual(num_file, 0)
 
-        self.phoSim_repackager.process_visit_eimage(
+        self.phoSim_repackager_lsstcam.process_visit_eimage(
             self.test_data_dir_eimg, out_dir=self.tmp_test_dir, instName="lsst"
         )
 
@@ -131,7 +140,7 @@ class TestPhoSimRepackager(unittest.TestCase):
         num_file = self._get_num_of_file_in_dir(self.tmp_test_dir)
         self.assertEqual(num_file, 0)
 
-        self.phoSim_repackager.repackage_eimage(
+        self.phoSim_repackager_lsstcam.repackage_eimage(
             self.eimg_file_path, out_dir=self.tmp_test_dir
         )
 
@@ -201,7 +210,7 @@ class TestPhoSimRepackager(unittest.TestCase):
         num_file = self._get_num_of_file_in_dir(self.tmp_test_dir)
         self.assertEqual(num_file, 0)
 
-        self.phoSim_repackager.process_visit(
+        self.phoSim_repackager_lsstcam.process_visit(
             self.test_data_dir_amp, out_dir=self.tmp_test_dir, instName="lsst"
         )
 
@@ -225,7 +234,8 @@ class TestPhoSimRepackager(unittest.TestCase):
         num_file = self._get_num_of_file_in_dir(self.tmp_test_dir)
         self.assertEqual(num_file, 0)
 
-        self.phoSim_repackager.repackage(self.amp_file_paths, out_dir=self.tmp_test_dir)
+        self.phoSim_repackager_lsstcam.repackage(self.amp_file_paths,
+                                                 out_dir=self.tmp_test_dir)
 
         num_file = self._get_num_of_file_in_dir(self.tmp_test_dir)
         self.assertEqual(num_file, 1)
@@ -255,6 +265,7 @@ class TestPhoSimRepackager(unittest.TestCase):
         self.assertEqual(header["RA"], 0.0)
         self.assertEqual(header["FILTER"], "g")
         self.assertEqual(header["IMGTYPE"], "SKYEXP")
+        self.assertEqual(header["FOCUSZ"], -1500)
 
         # Check the amp header information
         header = hdul[1].header
@@ -303,6 +314,7 @@ class TestPhoSimRepackager(unittest.TestCase):
         self.assertEqual(header["RA"], 0.0)
         self.assertEqual(header["FILTER"], "g_01")
         self.assertEqual(header["IMGTYPE"], "SKYEXP")
+        self.assertEqual(header["FOCUSZ"], -1500)
 
         # Check the amp header information
         header = hdul[1].header
@@ -350,6 +362,7 @@ class TestPhoSimRepackager(unittest.TestCase):
         self.assertEqual(header["RA"], 0.0)
         self.assertEqual(header["FILTER"], "g")
         self.assertEqual(header["IMGTYPE"], "DARK")
+        self.assertEqual(header["FOCUSZ"], 0)
 
         # Check the amp header information
         header = hdul[1].header


### PR DESCRIPTION
Add `focusz` kwarg to phosim repackager allowing to convey information on whether the piston images are intra or extra-focal. 