### PR TITLE
DM-40119: update lsstCam physical_filter names

### DIFF
--- a/python/lsst/phosim/utils/phosim_repackager.py
+++ b/python/lsst/phosim/utils/phosim_repackager.py
@@ -48,7 +48,7 @@ def updateLsstCamSpecificData(header):
     for obs_lsst. The list of currently accepted filters
     can be checked for an LSSTCam repo for
 
-    butler query-dimension-records . physical_filter
+    butler query-dimension-records $REPO_DIR physical_filter
 
     Parameters
     ----------
@@ -279,9 +279,9 @@ class PhoSimRepackager:
             )
 
             # Set the filter information.
-            # Both for comCam abd lsstCam the physical_filter needs
-            # to have names compatible with obs_lsst filters.py
-            # phosim filter names (ugrizy) do not correspond to
+            # Both for comCam and lsstCam the physical_filter needs
+            # to have names compatible with obs_lsst filters.
+            # Phosim filter names (ugrizy) do not correspond to
             # physical_filter names known by obs_lsst.
             if self.instrument == "comCam":
                 hdu.header = updateComCamSpecificData(hdu.header)
@@ -453,9 +453,9 @@ class PhoSimRepackager:
         ).mjd
 
         # Set the filter information.
-        # Both for comCam abd lsstCam the physical_filter needs
-        # to have names compatible with obs_lsst filters.py
-        # phosim filter names (ugrizy) do not correspond to
+        # Both for comCam and lsstCam the physical_filter needs
+        # to have names compatible with obs_lsst filters.
+        # Phosim filter names (ugrizy) do not correspond to
         # physical_filter names known by obs_lsst.
         if self.instrument == "comCam":
             sensor.header = updateComCamSpecificData(sensor.header)

--- a/tests/test_phosim_repackager.py
+++ b/tests/test_phosim_repackager.py
@@ -30,6 +30,7 @@ from lsst.utils import getPackageDir
 from lsst.phosim.utils.phosim_repackager import (
     PhoSimRepackager,
     updateComCamSpecificData,
+    updateLsstCamSpecificData
 )
 
 
@@ -281,7 +282,7 @@ class TestPhoSimRepackager(unittest.TestCase):
         self.assertEqual(header["LSST_NUM"], "E2V-CCD250-370")
         self.assertEqual(header["OBSID"], "MC_H_20000217_006001")
         self.assertEqual(header["RA"], 0.0)
-        self.assertEqual(header["FILTER"], "g")
+        self.assertEqual(header["FILTER"], "g_6")
         self.assertEqual(header["IMGTYPE"], "SKYEXP")
         self.assertEqual(header["FOCUSZ"], -1500)
 
@@ -398,7 +399,7 @@ class TestPhoSimRepackager(unittest.TestCase):
         self.assertEqual(header["LSST_NUM"], "E2V-CCD250-370")
         self.assertEqual(header["OBSID"], "MC_H_20000217_006001")
         self.assertEqual(header["RA"], 0.0)
-        self.assertEqual(header["FILTER"], "g")
+        self.assertEqual(header["FILTER"], "g_6")
         self.assertEqual(header["IMGTYPE"], "DARK")
         self.assertEqual(header["FOCUSZ"], 0)
 
@@ -438,6 +439,24 @@ class TestPhoSimRepackager(unittest.TestCase):
         # try updating header with unknown filter name
         wrong_header = fits.Header({"FILTER": "x"})
         self.assertRaises(ValueError, updateComCamSpecificData, wrong_header)
+
+    def test_updateLsstCamSpecificData(self):
+
+        # update header for raw comcam amp file
+        hdul = fits.open(self.amp_file_paths[0])
+        input_header = hdul[0].header
+        self.assertEqual(input_header["FILTER"], "g")
+
+        # test that the header got updated
+        updated_header = updateLsstCamSpecificData(input_header)
+        self.assertEqual(updated_header["FILTER"], "g_6")
+
+        # Close the file
+        hdul.close()
+
+        # try updating header with unknown filter name
+        wrong_header = fits.Header({"FILTER": "x"})
+        self.assertRaises(ValueError, updateLsstCamSpecificData, wrong_header)
 
 
 if __name__ == "__main__":


### PR DESCRIPTION
Adding a dictionary from phosim `ugrizy` filters to those accepted by butler. Tested with 
```butler query-dimension-records . physical_filter  ```
Now when instrument is `lsst`, repackaged files can be ingested to a butler repo. 